### PR TITLE
Add LDAP query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ My experiments in weaponizing [Nim](https://nim-lang.org/) for implant developme
 | [unhook.nim](../master/src/unhook.nim) | Unhooks ntdll.dll to evade EDR/AV hooks (pure nim implementation) |
 | [taskbar_ewmi_bin.nim](../master/src/taskbar_ewmi_bin.nim) | Uses Extra Window Memory Injection via Running Application property of TaskBar in order to execute the shellcode. |
 | [fork_dump_bin.nim](../master/src/fork_dump_bin.nim) | (ab)uses Window's implementation of `fork()` and acquires a handle to a remote process using the PROCESS_CREATE_PROCESS access right. It then attempts to dump the forked processes memory using `MiniDumpWriteDump()` |
+| [ldap_query_bin.nim](../master/src/ldap_query_bin.nim) | Perform LDAP queries via COM by using ADO's ADSI provider |
 
 ## Examples that are a WIP
 

--- a/src/ldap_query_bin.nim
+++ b/src/ldap_query_bin.nim
@@ -1,0 +1,61 @@
+#[
+    Author: @fkadibs
+    License: BSD 3-Clause
+
+    This is an example of querying Active Directory by using ADO's ADSI provider
+]#
+
+import winim/com
+import strformat
+
+# Connect to ADSI via ADO COM interface
+var conn = CreateObject("ADODB.Connection")
+conn.Provider = "ADsDSOObject"
+#conn.Properties("User ID") = <username>
+#conn.Properties("Password") = <password>
+#conn.Properties("Encrypt Password") = true
+conn.Open("Active Directory Provider")
+
+
+# Create query object to connection
+var command = CreateObject("ADODB.Command")
+command.ActiveConnection = conn
+# command.Properties("Page Size") = 100
+
+
+# Retrieve DNS name of domain controller
+var sysinfo = CreateObject("ADSystemInfo")
+var dn = sysinfo.DomainDNSName
+var root = fmt"<LDAP://{dn}>"
+
+
+# Build and execute LDAP query
+var queryFilter = "(&(objectCategory=person)(objectClass=user))"
+var queryAttrib = "cn,distinguishedName"
+var queryText = fmt"{root};{queryFilter};{queryAttrib};SubTree"
+command.CommandText = queryText
+var records = command.Execute()
+
+
+# Check for empty recordset
+if (records.BOF == true) and (records.EOF == true):
+    echo "No records found"
+
+
+# Iterate over recordset
+else:
+    records.MoveFirst()
+    while records.EOF == false:
+        # Iterate over row fields
+        var i = 0
+        var row: string
+        while i < records.Fields.Count:
+            var field = records.Fields.Item(i)
+            row = fmt"{row}{field} "
+            inc i
+        echo row
+        records.MoveNext()
+
+# Cleanup
+records.Close()
+conn.Close()


### PR DESCRIPTION
This is an example of how to execute LDAP queries using the ADO COM interface's ADSI provider. Nothing revolutionary, but navigating ADO records can be cumbersome, so this demonstrates how to do that reliably in nim.