### PR TITLE
Add list_remote_shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ My experiments in weaponizing [Nim](https://nim-lang.org/) for implant developme
 | [fork_dump_bin.nim](../master/src/fork_dump_bin.nim) | (ab)uses Window's implementation of `fork()` and acquires a handle to a remote process using the PROCESS_CREATE_PROCESS access right. It then attempts to dump the forked processes memory using `MiniDumpWriteDump()` |
 | [ldap_query_bin.nim](../master/src/ldap_query_bin.nim) | Perform LDAP queries via COM by using ADO's ADSI provider |
 | [sandbox_process_bin.nim](../master/src/sandbox_process_bin.nim) | This sandboxes a process by setting it's integrity level to Untrusted and strips important tokens. This can be used to "silently disable" a PPL process (e.g. AV/EDR) |
+| [list_remote_shares.nim](../master/src/list_remote_shares.nim) | Use NetShareEnum to list the share accessible by the current user |
 
 ## Examples that are a WIP
 

--- a/src/list_remote_shares.nim
+++ b/src/list_remote_shares.nim
@@ -1,0 +1,35 @@
+import winim
+import std/parseopt
+import os
+
+var target = ""
+var p = initOptParser(commandLineParams())
+while true:
+  p.next()
+  case p.kind
+  of cmdEnd: break
+  of cmdArgument:
+    target = p.key
+  else:
+    discard
+if target == "":
+    echo("Usage: ", getAppFilename(), " <serverName>")
+    quit(1)
+    
+var structSize = sizeOf(typeof(SHARE_INFO_502))
+var buf: PSHARE_INFO_502
+var entriesread: DWORD
+entriesread = 0
+var totalentries: DWORD
+totalentries = 0
+var resume_handle: DWORD
+resume_handle = 0
+var ret = NetShareEnum(target,502,cast[ptr LPBYTE](&buf), MAX_PREFERRED_LENGTH, &entriesread, &totalentries,&resume_handle)
+if NT_SUCCESS(ret) == true:
+    var currentPtr = buf
+    for i in 1 .. entriesread:
+        echo(currentPtr.shi502_netname, " -> ", currentPtr.shi502_path)
+        currentPtr = cast[PSHARE_INFO_502](cast[int](currentPtr) + cast[int](structSize))
+    NetApiBufferFree(buf);
+
+


### PR DESCRIPTION
Add a script to use NetShareEnum Win32 API to enumerate the share accessible on a remote server by the current user. 
No need to provide credentials, but It should be run on Windows.