### PR TITLE
Simple Anti-analysis IsDebuggerPresent POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ My experiments in weaponizing [Nim](https://nim-lang.org/) for implant developme
 | [dns_exfiltrate.nim](../master/src/dns_exfiltrate.nim) | Simple DNS exfiltration via TXT record queries |
 | [rsrc_section_shellcode.nim](../master/src/rsrc_section_shellcode.nim) | Execute shellcode embedded in the .rsrc section of the binary |
 | [token_steal_cmd.nim](../master/src/token_steal_cmd.nim) | Steal a token/impersonate and then run a command | 
+| [anti_analysis_isdebuggerpresent.nim](../master/src/anti_analysis_isdebuggerpresent.nim) | Simple anti-analysis that checks for a debugger | 
+
 
 ## Examples that are a WIP
 
@@ -199,7 +201,7 @@ nim c -d=mingw --app=lib --nomain --cpu=amd64 mynim.dll
 ### Creating XLLs
 You can make an XLL (an Excel DLL, imagine that) with an auto open function that can be used for payload delivery. The following code creates a simple for an XLL that has an auto open function and all other boilerplate code needed to compile as a link library. The POC compiles as a DLL, you can then change the extension to .xll and it will open in Excel and run the payload when double clicked:
 
-```
+```nim
 #[
     Compile:
         nim c -d=mingw --app=lib --nomain --cpu=amd64 nim_xll.nim

--- a/src/anti_analysis_isdebuggerpresent.nim
+++ b/src/anti_analysis_isdebuggerpresent.nim
@@ -1,0 +1,38 @@
+#[
+    Author: HuskyHacks
+    License: BSD 3-Clause
+
+    Compile:
+        nim c -d:mingw --cpu=amd64 --app=console simpleAntiAnalysis.nim
+]#
+
+import winim
+
+# If you want to see the console out with an --app=console build, uncomment this import
+# import strformat
+
+# Uncomment for convinience breakpoint function that hangs the program until you hit enter in the console window
+# proc breakpoint(): void =
+#     discard(readLine(stdin))
+
+# Using winim's library to perform the check and convert the WINBOOL result into a simple bool for ease of access
+proc checkForDebugger(): bool =
+    winimConverterBOOLToBoolean(IsDebuggerPresent())
+
+proc main(): void =
+    let debuggerIsDetected = checkForDebugger()
+    # Uncomment to see the console output in an --app=console build
+    # echo fmt"[*] Debugger Detected: {debuggerIsDetected}"
+
+    if debuggerIsDetected:
+        MessageBox(0, "Oh, you think you're slick, huh? I see your debugger over there. No soup for you!", "MEGASUSBRO", 0)
+        quit(1)
+    else:
+        MessageBox(0, "No debugger detected! Cowabunga, dudes!", "COAST IS CLEAR", 0)
+        MessageBox(0, "Boom!", "PAYLOAD", 0)
+    
+    # Breakpoint for convinience
+    # breakpoint()
+
+when isMainModule:
+    main()


### PR DESCRIPTION
A simple POC that includes a naive anti-analysis technique. Leverages winim to perform the IsDebuggerPresent API call and convert the result to a Nim navite bool value. Then splits the flow of the program based on the outcome of that call.

Contains messagebox payloads but can easily be outfitted for weaponization.